### PR TITLE
Azuregos' Mark of Frost debuff should persist through wipe and reset

### DIFF
--- a/src/server/scripts/Kalimdor/boss_azuregos.cpp
+++ b/src/server/scripts/Kalimdor/boss_azuregos.cpp
@@ -27,7 +27,6 @@ enum Say
 {
     SAY_TELEPORT = 0,
     SAY_AGGRO,
-    SAY_KILL,
 };
 
 enum Spells
@@ -62,8 +61,6 @@ public:
 
         void Reset() override
         {
-            me->RemoveAurasDueToSpell(SPELL_MARK_OF_FROST_AURA);
-            _scheduler.CancelAll();
             me->SetNpcFlag(UNIT_NPC_FLAG_GOSSIP);
             me->RestoreFaction();
             me->GetMap()->DoForAllPlayers([&](Player* p)
@@ -71,7 +68,6 @@ public:
                     if (p->GetZoneId() == me->GetZoneId())
                     {
 
-                        p->RemoveAurasDueToSpell(SPELL_MARK_OF_FROST);
                         p->RemoveAurasDueToSpell(SPELL_AURA_OF_FROST);
                         p->RemoveAurasDueToSpell(SPELL_CHILL);
                         p->RemoveAurasDueToSpell(SPELL_FROST_BREATH);
@@ -83,7 +79,6 @@ public:
         {
             if (victim && victim->GetTypeId() == TYPEID_PLAYER)
             {
-                Talk(SAY_KILL);
                 victim->CastSpell(victim, SPELL_MARK_OF_FROST, true);
             }
         }


### PR DESCRIPTION
Fixes Issue #11343

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Removes removal of mark of frost debuff on Death
-  Applies Mark of Frost to last player alive
- Removed Yell_Kill Sine it just gives errors that you cannot chat while dead

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 
Issue 11343
## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Tested in Small raid 
- Wiped team
- Debuff persists
- Debuff applied to last player alive


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. In a group go to Azuregos
2. .go creature 52349
3. Wipe on Azuregos
4. Mark of Frost on Last Player to die?
5. Mark of Frost persist through death?
6.Joy

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
